### PR TITLE
only publish stable and beta

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -12,8 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         # channel: ["Stable", "Beta", "Dev", "Canary"]
-        # only run stable channel until pypi storage problem is fixed
-        channel: ["Stable"]
+        # only run stable & beta channel until pypi storage problem is fixed
+        channel: ["Stable", "Beta"]
     runs-on: ubuntu-latest
     steps:
       -


### PR DESCRIPTION
as mentioned in #42 i rely on the beta version, but not necessarily the dev or canary versions, so hopefully only publishing these two won't hit the quota?